### PR TITLE
Crud denuncia

### DIFF
--- a/src/main/java/com/vitalu/flop/controller/DenunciaController.java
+++ b/src/main/java/com/vitalu/flop/controller/DenunciaController.java
@@ -1,5 +1,96 @@
 package com.vitalu.flop.controller;
 
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import com.vitalu.flop.auth.AuthService;
+import com.vitalu.flop.exception.FlopException;
+import com.vitalu.flop.model.dto.DenunciaDTO;
+import com.vitalu.flop.model.entity.Denuncia;
+import com.vitalu.flop.model.entity.Usuario;
+import com.vitalu.flop.model.enums.StatusDenuncia;
+import com.vitalu.flop.model.seletor.DenunciaSeletor;
+import com.vitalu.flop.service.DenunciaService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import jakarta.validation.Valid;
+
+@RestController
+@RequestMapping(path = "/denuncias")
+@CrossOrigin(origins = { "http://localhost:4200" }, maxAge = 3600)
 public class DenunciaController {
+
+	@Autowired
+	private DenunciaService denunciaService;
+
+	@Autowired
+	private AuthService authService;
+
+	@Operation(summary = "Inserir nova denuncia", description = "Cria uma nova denuncia", responses = {
+			@ApiResponse(responseCode = "200", description = "Denuncia registrada com sucesso"), })
+	@PostMapping("/cadastrar")
+	public ResponseEntity<Denuncia> cadastrar(@Valid @RequestBody Denuncia denuncia) throws FlopException {
+		Usuario subject = authService.getUsuarioAutenticado();
+
+		denuncia.setUsuarioDenunciador(subject);
+
+		return ResponseEntity.ok(denunciaService.cadastrar(denuncia));
+	}
+
+	@Operation(summary = "Atualizar status da denuncia", description = "Atualiza o status da denuncia", responses = {
+			@ApiResponse(responseCode = "200", description = "Status da denuncia atualizado com sucesso"),
+			@ApiResponse(responseCode = "400", description = "Denuncia não encontrada") })
+	@PutMapping("/atualizar/{idDenuncia}")
+	public ResponseEntity<Void> atualizar(@PathVariable Long idDenuncia, @RequestBody StatusDenuncia statusDenuncia)
+			throws FlopException {
+		denunciaService.atualizar(idDenuncia, statusDenuncia);
+		return ResponseEntity.ok().build();
+	}
+
+	@Operation(summary = "Excluir denuncia", description = "Exclui a denuncia", responses = {
+			@ApiResponse(responseCode = "200", description = "Denuncia excluida com sucesso"),
+			@ApiResponse(responseCode = "400", description = "Denuncia não encontrada") })
+	@DeleteMapping("/excluir/{idDenuncia}")
+	public ResponseEntity<Void> excluir(@PathVariable Long idDenuncia) throws FlopException {
+		Usuario subject = authService.getUsuarioAutenticado();
+
+		denunciaService.excluir(idDenuncia, subject.getIdUsuario());
+		return ResponseEntity.ok().build();
+	}
+
+	@Operation(summary = "Pesquisar todas as denúncias", description = "Retorna uma lista com todas as denúncias cadastradas.", responses = {
+			@ApiResponse(responseCode = "200", description = "Denuncias retornadas com sucesso."),
+			@ApiResponse(responseCode = "400", description = "Denuncias não encontradas."),
+			@ApiResponse(responseCode = "401", description = "Usuário não autorizado.") })
+	@GetMapping("/todas")
+	public List<DenunciaDTO> pesquisarTodas() throws FlopException {
+		return denunciaService.pesquisarTodas();
+	}
+
+	@Operation(summary = "Pesquisar uma denúncia pelo id", description = "Retorna denuncia especifica para o admin.", responses = {
+			@ApiResponse(responseCode = "200", description = "Denuncia retornada com sucesso."),
+			@ApiResponse(responseCode = "400", description = "Denuncia não encontrada."),
+			@ApiResponse(responseCode = "401", description = "Usuário não autorizado.") })
+	@GetMapping("/{id}")
+	public ResponseEntity<DenunciaDTO> pesquisarPorId(@PathVariable Long id) throws FlopException {
+		DenunciaDTO denuncia = denunciaService.pesquisarPorId(id);
+		return ResponseEntity.ok(denuncia);
+	}
+
+	@Operation(summary = "Pesquisar com filtro", description = "Retorna uma lista de denúncias de acordo com o filtro selecionado.")
+	@PostMapping("/filtrar")
+	public List<DenunciaDTO> pesquisarComFiltros(@RequestBody DenunciaSeletor seletor) {
+		return denunciaService.pesquisarComFiltros(seletor);
+	}
 
 }

--- a/src/main/java/com/vitalu/flop/model/dto/DenunciaDTO.java
+++ b/src/main/java/com/vitalu/flop/model/dto/DenunciaDTO.java
@@ -1,0 +1,25 @@
+package com.vitalu.flop.model.dto;
+
+import java.time.LocalDateTime;
+
+import com.vitalu.flop.model.enums.MotivosDenuncia;
+import com.vitalu.flop.model.enums.StatusDenuncia;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class DenunciaDTO {
+
+	private String id;
+	private String nomeDenunciante;
+	private String postagemId;
+	private String textoPostagem;
+	private String imagemPostagem;
+	private String usuarioId;
+	private String nomeUsuario;
+	private MotivosDenuncia motivo;
+	private StatusDenuncia status;
+	private LocalDateTime criadoEm;
+	
+}

--- a/src/main/java/com/vitalu/flop/model/entity/Denuncia.java
+++ b/src/main/java/com/vitalu/flop/model/entity/Denuncia.java
@@ -4,7 +4,9 @@ import java.time.LocalDateTime;
 
 import org.hibernate.annotations.CreationTimestamp;
 
+import com.vitalu.flop.model.dto.DenunciaDTO;
 import com.vitalu.flop.model.enums.MotivosDenuncia;
+import com.vitalu.flop.model.enums.StatusDenuncia;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -14,6 +16,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
 @Entity
@@ -38,5 +41,23 @@ public class Denuncia {
 	@Enumerated(EnumType.STRING)
 	private MotivosDenuncia motivo;
 
-	private Boolean analisada;
+	@Enumerated(EnumType.STRING)
+	@NotNull
+	private StatusDenuncia status = StatusDenuncia.PENDENTE;
+
+	public static DenunciaDTO toDTO(Denuncia denuncia) {
+	    return new DenunciaDTO(
+	        String.valueOf(denuncia.getIdDenuncia()),  // Convertendo Long para String
+	        denuncia.getUsuarioDenunciador().getNome(),
+	        String.valueOf(denuncia.getPostagem().getIdPostagem()),  // Convertendo Long para String
+	        denuncia.getPostagem().getMensagem(),
+	        denuncia.getPostagem().getImagem(),
+	        String.valueOf(denuncia.getUsuarioDenunciador().getIdUsuario()),  // Convertendo Long para String
+	        denuncia.getPostagem().getUsuario().getNome(),
+	        denuncia.getMotivo(),
+	        denuncia.getStatus(),
+	        denuncia.getCriadoEm()
+	    );
+	}
+
 }

--- a/src/main/java/com/vitalu/flop/model/enums/StatusDenuncia.java
+++ b/src/main/java/com/vitalu/flop/model/enums/StatusDenuncia.java
@@ -1,0 +1,5 @@
+package com.vitalu.flop.model.enums;
+
+public enum StatusDenuncia {
+	PENDENTE, ACEITA, RECUSADA
+}

--- a/src/main/java/com/vitalu/flop/model/repository/DenunciaRepository.java
+++ b/src/main/java/com/vitalu/flop/model/repository/DenunciaRepository.java
@@ -1,5 +1,11 @@
 package com.vitalu.flop.model.repository;
 
-public class DenunciaRepository {
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.stereotype.Repository;
+import com.vitalu.flop.model.entity.Denuncia;
+
+@Repository
+public interface DenunciaRepository extends JpaRepository<Denuncia, Long>, JpaSpecificationExecutor<Denuncia> {
 
 }

--- a/src/main/java/com/vitalu/flop/model/seletor/DenunciaSeletor.java
+++ b/src/main/java/com/vitalu/flop/model/seletor/DenunciaSeletor.java
@@ -1,0 +1,53 @@
+package com.vitalu.flop.model.seletor;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.data.jpa.domain.Specification;
+import com.vitalu.flop.model.entity.Denuncia;
+import com.vitalu.flop.model.enums.MotivosDenuncia;
+import com.vitalu.flop.model.enums.StatusDenuncia;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import lombok.Data;
+
+@Data
+public class DenunciaSeletor extends BaseSeletor implements Specification<Denuncia> {
+
+	private String idUsuario;
+	private String idPostagem;
+	private MotivosDenuncia motivo;
+	private StatusDenuncia status;
+	private LocalDateTime criadoEmInicio;
+	private LocalDateTime criadoEmFim;
+
+	@Override
+	public Predicate toPredicate(Root<Denuncia> root, CriteriaQuery<?> query, CriteriaBuilder cb) {
+		List<Predicate> predicates = new ArrayList<>();
+
+		if (this.getIdUsuario() != null) {
+			predicates.add(cb.equal(root.get("usuario").get("id"), this.getIdUsuario()));
+		}
+
+		if (this.getIdPostagem() != null) {
+			predicates.add(cb.equal(root.get("pruu").get("id"), this.getIdPostagem()));
+		}
+
+		if (this.getMotivo() != null) {
+			predicates.add(cb.equal(root.get("motivo"), this.getMotivo()));
+		}
+
+		if (this.getStatus() != null) {
+			predicates.add(cb.equal(root.get("status"), this.getStatus()));
+		}
+
+		if (this.criadoEmInicio != null && this.criadoEmFim != null) {
+			filtrarPorData(root, cb, predicates, this.getCriadoEmInicio(), this.getCriadoEmFim(), "criadoEm");
+		}
+
+		return cb.and(predicates.toArray(new Predicate[0]));
+	}
+}

--- a/src/main/java/com/vitalu/flop/service/DenunciaService.java
+++ b/src/main/java/com/vitalu/flop/service/DenunciaService.java
@@ -1,5 +1,123 @@
 package com.vitalu.flop.service;
 
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+import com.vitalu.flop.exception.FlopException;
+import com.vitalu.flop.model.dto.DenunciaDTO;
+import com.vitalu.flop.model.entity.Denuncia;
+import com.vitalu.flop.model.entity.Postagem;
+import com.vitalu.flop.model.entity.Usuario;
+import com.vitalu.flop.model.enums.MotivosDenuncia;
+import com.vitalu.flop.model.enums.StatusDenuncia;
+import com.vitalu.flop.model.repository.DenunciaRepository;
+import com.vitalu.flop.model.repository.PostagemRepository;
+import com.vitalu.flop.model.repository.UsuarioRepository;
+import com.vitalu.flop.model.seletor.DenunciaSeletor;
+
+@Service
 public class DenunciaService {
+	@Autowired
+	private DenunciaRepository denunciaRepository;
+
+	@Autowired
+	private PostagemRepository postagemRepository;
+
+	@Autowired
+	private UsuarioRepository usuarioRepository;
+
+	public Denuncia cadastrar(Denuncia denuncia) throws FlopException {
+		if (denuncia.getMotivo() == null || !EnumSet.allOf(MotivosDenuncia.class).contains(denuncia.getMotivo())) {
+			throw new FlopException("Motivo de denúncia inválido.", HttpStatus.BAD_REQUEST);
+		}
+
+		Postagem postDenunciado = postagemRepository.findById(denuncia.getPostagem().getIdPostagem())
+				.orElseThrow(() -> new FlopException("Pruu não encontrado.", HttpStatus.BAD_REQUEST));
+		Usuario autorDaDenuncia = usuarioRepository.findById(denuncia.getUsuarioDenunciador().getIdUsuario())
+				.orElseThrow(() -> new FlopException("Usuário não encontrado.", HttpStatus.BAD_REQUEST));
+
+		denuncia.setPostagem(postDenunciado);
+		denuncia.setUsuarioDenunciador(autorDaDenuncia);
+
+		return denunciaRepository.save(denuncia);
+	}
+
+	public void atualizar(Long idDenuncia, StatusDenuncia novoStatus) throws FlopException {
+		Denuncia denuncia = denunciaRepository.findById(idDenuncia)
+				.orElseThrow(() -> new FlopException("Denúncia não encontrada.", HttpStatus.BAD_REQUEST));
+		Postagem postagem = denuncia.getPostagem();
+
+		atualizarStatusPruu(postagem, denuncia.getStatus(), novoStatus);
+
+		denuncia.setStatus(novoStatus);
+		denunciaRepository.save(denuncia);
+	}
+
+	// Não será possivel excluir uma denuncia.
+	public void excluir(Long idDenuncia, Long idUsuario) throws FlopException {
+		Denuncia denuncia = denunciaRepository.findById(idDenuncia)
+				.orElseThrow(() -> new FlopException("A denúncia buscada não foi encontrada.", HttpStatus.BAD_REQUEST));
+
+		if (denuncia.getUsuarioDenunciador().getIdUsuario().equals(idUsuario)) {
+			denunciaRepository.deleteById(idDenuncia);
+		} else {
+			throw new FlopException("Não é possível excluir denúncias que não foram feitas por você.",
+					HttpStatus.BAD_REQUEST);
+		}
+	}
+	
+	 public List<DenunciaDTO> pesquisarTodas() {
+	        List<Denuncia> denuncias =  denunciaRepository.findAll();
+	        return toDenunciaDTO(denuncias);
+	    }
+
+	    public DenunciaDTO pesquisarPorId(Long idDenuncia) throws FlopException {
+	        Denuncia denuncia = denunciaRepository.findById(idDenuncia).orElseThrow(() -> new FlopException("A denúncia buscada não foi encontrada.", HttpStatus.BAD_REQUEST));
+	        return Denuncia.toDTO(denuncia);
+	    }
+
+	    public List<DenunciaDTO> pesquisarComFiltros(DenunciaSeletor seletor) {
+	        List<Denuncia> denuncias;
+
+	        if (seletor.temPaginacao()) {
+	            int pageNumber = seletor.getPagina();
+	            int pageSize = seletor.getLimite();
+
+	            PageRequest page = PageRequest.of(pageNumber - 1, pageSize);
+	            denuncias = denunciaRepository.findAll(seletor, page).toList();
+	        }
+
+	        denuncias = denunciaRepository.findAll(seletor);
+
+	        return toDenunciaDTO(denuncias);
+	    }
+
+	    public List<DenunciaDTO> toDenunciaDTO(List<Denuncia> denuncias) {
+	        List<DenunciaDTO> denunciasDTO = new ArrayList<>();
+
+	        for (Denuncia d : denuncias) {
+	            DenunciaDTO dto = Denuncia.toDTO(d);
+	            denunciasDTO.add(dto);
+
+	        }
+	        return denunciasDTO;
+	    }
+
+	void atualizarStatusPruu(Postagem postagem, StatusDenuncia statusAtual, StatusDenuncia novoStatus) {
+		if (novoStatus == StatusDenuncia.ACEITA) {
+			postagem.setExcluida(true);
+		} else if (statusAtual == StatusDenuncia.ACEITA
+				&& (novoStatus == StatusDenuncia.RECUSADA || novoStatus == StatusDenuncia.PENDENTE)) {
+			postagem.setExcluida(false);
+		}
+
+		postagemRepository.save(postagem);
+	}
 
 }


### PR DESCRIPTION
# Descrição
Implementada funcionalidade completa de CRUD para Denúncia. Permite que os usuários denunciem postagens, associando a denúncia a um motivo e ao usuário denunciante. Também permite aos administradores realizar ações como atualizar o status das denúncias e excluí-las quando necessário. Para isso, foram feitas alterações nas entidades Denuncia, Postagem e Usuario, além da criação de um DTO (DenunciaDTO) para transferir dados de forma adequada.
## Tipo de mudança

- [ ] Bug fix (mudança que resolve um problema/ocorrência)
- [X] Nova feature (mudança que adiciona uma nova funcionalidade)
- [ ] Breaking change (fix ou feature que altera o funcionamento de uma funcionalidade existente)
- [ ] Essa mudança requer alterações na documentação.
