### PR TITLE
Feature/crud/praia

### DIFF
--- a/src/main/java/com/vitalu/flop/controller/PraiaController.java
+++ b/src/main/java/com/vitalu/flop/controller/PraiaController.java
@@ -3,19 +3,28 @@ package com.vitalu.flop.controller;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.vitalu.flop.auth.AuthService;
 import com.vitalu.flop.exception.FlopException;
 import com.vitalu.flop.model.entity.Praia;
+import com.vitalu.flop.model.entity.Usuario;
 import com.vitalu.flop.service.PraiaService;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import jakarta.validation.Valid;
 
 @RestController
 @RequestMapping(path = "/praia")
@@ -24,6 +33,23 @@ public class PraiaController {
 
 	@Autowired
 	private PraiaService praiaService;
+
+	@Autowired
+	private AuthService authService;
+
+	@Operation(summary = "Inserir nova praia.", responses = {
+			@ApiResponse(responseCode = "200", description = "Praia criada com sucesso!", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Praia.class))),
+			@ApiResponse(responseCode = "400", description = "Erro de validação ou regra de negócio.", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = "{\"message\": \"Erro de validação: campo X é obrigatório\", \"status\": 400}"))) })
+	@PostMapping(path = "/cadastrar")
+	public ResponseEntity<Praia> cadastrarPraia(@Valid @RequestBody Praia novaPraia) throws FlopException {
+		Usuario subject = authService.getUsuarioAutenticado();
+		if (subject.isAdmin() == true) {
+			Praia praiaCriada = praiaService.cadastrarPraia(novaPraia);
+			return ResponseEntity.status(201).body(praiaCriada);
+		} else {
+			throw new FlopException("Usuários não podem criar novas praias.", HttpStatus.BAD_REQUEST);
+		}
+	}
 
 	@Operation(summary = "Listar todas as praias.", description = "Retorna uma lista de todas as praias cadastrados no sistema.", responses = {
 			@ApiResponse(responseCode = "200", description = "Lista de praias retornada com sucesso") })

--- a/src/main/java/com/vitalu/flop/controller/PraiaController.java
+++ b/src/main/java/com/vitalu/flop/controller/PraiaController.java
@@ -3,9 +3,10 @@ package com.vitalu.flop.controller;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -20,7 +21,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 @RequestMapping(path = "/praia")
 @CrossOrigin(origins = { "http://localhost:4200" }, maxAge = 3600)
 public class PraiaController {
-	
+
 	@Autowired
 	private PraiaService praiaService;
 
@@ -30,5 +31,11 @@ public class PraiaController {
 	public List<Praia> pesquisarTodos() throws FlopException {
 		return praiaService.pesquisarPraiaTodas();
 	}
-	
+
+	@Operation(summary = "Pesquisar praia por ID.", description = "Busca uma praia específica através do seu ID.")
+	@GetMapping(path = "/{idPraia}")
+	public ResponseEntity<Praia> pesquisarPraiasId(@PathVariable("idPraia") Long praiaId) throws FlopException {
+		Praia praia = praiaService.pesquisarPraiasId(praiaId);
+		return ResponseEntity.ok(praia);
+	}
 }

--- a/src/main/java/com/vitalu/flop/model/entity/Localizacao.java
+++ b/src/main/java/com/vitalu/flop/model/entity/Localizacao.java
@@ -25,7 +25,7 @@ public class Localizacao {
 
 	private String estado;
 
-	@OneToOne(mappedBy = "localizacao")
-	private Praia praia;
+//	@OneToOne(mappedBy = "localizacao")
+//	private Praia praia;
 
 }

--- a/src/main/java/com/vitalu/flop/model/entity/Praia.java
+++ b/src/main/java/com/vitalu/flop/model/entity/Praia.java
@@ -26,9 +26,9 @@ public class Praia {
 
 	private String imagem;
 
-	@OneToOne(cascade = CascadeType.ALL)
-	@JoinColumn(name = "idLocalizacao", referencedColumnName = "idLocalizacao")
-	private Localizacao localizacao;
+//	@OneToOne(cascade = CascadeType.ALL)
+//	@JoinColumn(name = "idLocalizacao", referencedColumnName = "idLocalizacao")
+//	private Localizacao localizacao;
 
 	@OneToMany(mappedBy = "praia")
 	private List<Avaliacao> avaliacoes;


### PR DESCRIPTION
# Descrição

## ✨ Cadastro e Consulta de Praia por ID + Ajustes nas Entidades

### Esta PR inclui as seguintes alterações:

- **Novo endpoint `POST /praia/cadastrar`**  
  Permite o cadastro de novas praias, acessível apenas para usuários administradores.

- **Novo endpoint `GET /praia/{idPraia}`**  
  Retorna os dados completos de uma praia a partir do seu ID.

- **Adaptações nas entidades `Praia` e `Localizacao`**  
  Suspensão do relacionamento Localizacao/Praia.

## Tipo de mudança

- [ ] Bug fix (mudança que resolve um problema/ocorrência)
- [x] Nova feature (mudança que adiciona uma nova funcionalidade)
- [ ] Breaking change (fix ou feature que altera o funcionamento de uma funcionalidade existente)
- [ ] Essa mudança requer alterações na documentação.
