### PR TITLE
fix: prevent circular reference between Praia and Avaliacao.

### DIFF
--- a/src/main/java/com/vitalu/flop/model/entity/Avaliacao.java
+++ b/src/main/java/com/vitalu/flop/model/entity/Avaliacao.java
@@ -34,6 +34,7 @@ public class Avaliacao {
 
 	@ManyToOne
 	@JoinColumn(name = "praia_id", nullable = false)
+	@JsonBackReference
 	private Praia praia;
 
 	@CreationTimestamp

--- a/src/main/java/com/vitalu/flop/model/entity/Praia.java
+++ b/src/main/java/com/vitalu/flop/model/entity/Praia.java
@@ -3,12 +3,16 @@ package com.vitalu.flop.model.entity;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
 
@@ -25,12 +29,12 @@ public class Praia {
 
 	private String imagem;
 
-//	@OneToOne(cascade = CascadeType.ALL)
-//	@JoinColumn(name = "idLocalizacao", referencedColumnName = "idLocalizacao")
-//	private Localizacao localizacao;
+	@OneToOne(cascade = CascadeType.ALL)
+	@JoinColumn(name = "idLocalizacao", referencedColumnName = "idLocalizacao")
+	private Localizacao localizacao;
 
 	@OneToMany(mappedBy = "praia")
-	@JsonIgnore
+	@JsonManagedReference
 	private List<Avaliacao> avaliacoes;
 
 	@OneToMany(mappedBy = "praia")


### PR DESCRIPTION
# Descrição

- Adicionadas as anotações `@JsonManagedReference` e `@JsonBackReference` para gerenciar relações bidirecionais e evitar a serialização circular.
- A anotação `@JsonManagedReference` foi aplicada em `Praia` para permitir a serialização de `avaliacoes`.
- A anotação `@JsonBackReference` foi aplicada em `Avaliacao` para evitar a referência circular para `Praia` durante a serialização.


## Tipo de mudança

- [x] Bug fix (mudança que resolve um problema/ocorrência)
- [ ] Nova feature (mudança que adiciona uma nova funcionalidade)
- [ ] Breaking change (fix ou feature que altera o funcionamento de uma funcionalidade existente)
- [ ] Essa mudança requer alterações na documentação.
